### PR TITLE
perf: centralize asset loading in ContentView to avoid duplicate Draw Things connections

### DIFF
--- a/DrawThingsStudio/ContentView.swift
+++ b/DrawThingsStudio/ContentView.swift
@@ -148,6 +148,13 @@ struct ContentView: View {
             }
         }
         .focusedSceneValue(\.workflowViewModel, workflowViewModel)
+        .task {
+            // Centralised asset loading: fetch Draw Things assets and the cloud model catalog
+            // once at the top level so child views (ImageGenerationView, WorkflowPipelineView)
+            // don't each trigger a redundant connection attempt on launch.
+            await DrawThingsAssetManager.shared.fetchAssets()
+            await DrawThingsAssetManager.shared.fetchCloudCatalogIfNeeded()
+        }
     }
 
     // MARK: - Drop Routing

--- a/DrawThingsStudio/ImageGenerationView.swift
+++ b/DrawThingsStudio/ImageGenerationView.swift
@@ -56,8 +56,6 @@ struct ImageGenerationView: View {
         }
         .task {
             await viewModel.checkConnection()
-            await assetManager.fetchAssets()
-            await assetManager.fetchCloudCatalogIfNeeded()
         }
     }
 

--- a/DrawThingsStudio/WorkflowPipelineView.swift
+++ b/DrawThingsStudio/WorkflowPipelineView.swift
@@ -82,8 +82,6 @@ struct WorkflowPipelineView: View {
         }
         .task {
             await viewModel.checkConnection()
-            await assetManager.fetchAssets()
-            await assetManager.fetchCloudCatalogIfNeeded()
         }
     }
 


### PR DESCRIPTION
Both ImageGenerationView and WorkflowPipelineView were rendered persistently in a
ZStack (always alive, hidden via opacity) and each called fetchAssets() +
fetchCloudCatalogIfNeeded() in their .task modifiers. This caused two concurrent
connection attempts to Draw Things on every app launch.

Move the shared asset-loading calls to a single ContentView.task. Child views
retain only their own viewModel.checkConnection() call for per-view UI state.

Addresses architecture observation #2 from CODE_AUDIT_REPORT.md.

https://claude.ai/code/session_013cksBcsgMMYwBLRwyArJJ1