### PR TITLE
Add copy button for assembled prompt in Story Studio

### DIFF
--- a/DrawThingsStudio/StoryStudioView.swift
+++ b/DrawThingsStudio/StoryStudioView.swift
@@ -660,7 +660,20 @@ struct StoryStudioView: View {
 
     private var promptPreviewSection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            NeuSectionHeader("Assembled Prompt")
+            HStack {
+                NeuSectionHeader("Assembled Prompt")
+                Spacer()
+                Button(action: {
+                    copyPromptToClipboard()
+                }) {
+                    Image(systemName: "doc.on.doc")
+                        .foregroundColor(.neuTextSecondary)
+                }
+                .buttonStyle(NeumorphicIconButtonStyle())
+                .help("Copy prompt to clipboard")
+                .accessibilityIdentifier("storyStudio_copyPrompt")
+            }
+            
             Text(viewModel.assembledPromptPreview)
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.neuTextSecondary)
@@ -668,6 +681,12 @@ struct StoryStudioView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .neuInset(cornerRadius: 8)
         }
+    }
+    
+    private func copyPromptToClipboard() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(viewModel.assembledPromptPreview, forType: .string)
     }
 
     private var generationControlsSection: some View {


### PR DESCRIPTION
## Summary

Adds a copy-to-clipboard button next to the "Assembled Prompt" section header in Story Studio.

Closes #8

## Changes

- Added a clipboard icon button (`doc.on.doc`) in `StoryStudioView.swift` next to the `NeuSectionHeader("Assembled Prompt")`
- Uses `NeuMorphicIconButtonStyle()` consistent with the existing design system
- Calls `NSPasteboard` to copy `viewModel.assembledPromptPreview` to clipboard
- Includes tooltip (`.help("Copy prompt to clipboard")`) and accessibility identifier (`storyStudio_copyPrompt`)

## Testing

Tested manually on macOS with an active Story Studio project — the assembled prompt is correctly copied to clipboard on button tap.